### PR TITLE
plugins.rst: changed link-text to omv-extras.org from "here" to "omv-extras.org"

### DIFF
--- a/plugins.rst
+++ b/plugins.rst
@@ -38,4 +38,4 @@ The following is the list of official plugins by |omv|.
 3rd party
 ---------
 
-An overview of the third party plugin list can be found `here <http://www.omv-extras.org/>`_.
+An overview of the third party plugin list can be found at `omv-extras.org <http://www.omv-extras.org/>`_.


### PR DESCRIPTION
Generally, it is a bad idea to put "here" as only link-option, as uxmovement's article called ['Why Your Links Should Never Say “Click Here”'](http://uxmovement.com/content/why-your-links-should-never-say-click-here) explains.

Basically, every time I see a "the list is [here]().", I wonder: "Where? There's no list HERE....". I fall for this every time, and I know people that got really frustrated by this.