### PR TITLE
--allow-unauthenticated or else it will not work..

### DIFF
--- a/installation/on_debian.rst
+++ b/installation/on_debian.rst
@@ -65,7 +65,7 @@ Install the |omv| 4 (Arrakis) package::
     apt-get update
     apt-get --allow-unauthenticated install openmediavault-keyring
     apt-get update
-    apt-get --yes --auto-remove --show-upgraded \
+    apt-get --yes --auto-remove --show-upgraded --allow-unauthenticated \
         --allow-downgrades --allow-change-held-packages \
         --no-install-recommends \
         --option Dpkg::Options::="--force-confdef" \


### PR DESCRIPTION
You have to add this as long as you don't provide a valid key for
`
WARNING: The following packages cannot be authenticated!
  libjs-extjs6 php-pam openmediavault
E: There were unauthenticated packages and -y was used without --allow-unauthenticated
.`