### PR TITLE
I tried some times to edit via nano but...

### DIFF
--- a/administration/general/powermanagement.rst
+++ b/administration/general/powermanagement.rst
@@ -6,7 +6,7 @@ Monitoring
 
 Configures cpufrequtils and sets the default options for the governor to be **conservative** by default in x86 architectures if enabled. If architecture is different then governor is set as **ondemand**.
 
-:file:`/etc/default/crupfrequtils`
+:file:`/etc/default/cpufrequtils`
 
 .. code-block:: guess
 


### PR DESCRIPTION
I tried some times to edit via nano this file, /etc/default/crupfrequtils, but doesn't exits, because the correct file is: /etc/default/cpufrequtils