### PR TITLE
openmediavault-keyring should be downloaded safely

### DIFF
--- a/installation/on_debian.rst
+++ b/installation/on_debian.rst
@@ -43,10 +43,15 @@ Install the |omv| 3 (Erasmus) package::
 Debian 9 (Stretch)
 ------------------
 
+Install HTTPS transport for APT to prevent MITM attact while downloading keyring::
+
+    apt-get update
+    apt-get --yes apt-transport-https
+
 Add the package repositories::
 
     cat <<EOF >> /etc/apt/sources.list.d/openmediavault.list
-    deb http://packages.openmediavault.org/public arrakis main
+    deb https://packages.openmediavault.org/public arrakis main
     # deb http://downloads.sourceforge.net/project/openmediavault/packages arrakis main
     ## Uncomment the following line to add software from the proposed repository.
     # deb http://packages.openmediavault.org/public arrakis-proposed main

--- a/installation/on_debian.rst
+++ b/installation/on_debian.rst
@@ -43,7 +43,7 @@ Install the |omv| 3 (Erasmus) package::
 Debian 9 (Stretch)
 ------------------
 
-Install HTTPS transport for APT to prevent MITM attact while downloading keyring::
+Install HTTPS transport for APT to prevent MITM attack while downloading keyring::
 
     apt-get update
     apt-get --yes apt-transport-https


### PR DESCRIPTION
It's 2019 year here. It's not safe to get keyring over HTTP without any authentication verification. The Docker approach isn't bad https://docs.docker.com/install/linux/docker-ce/debian/ -- `curl -fsSL https://download.docker.com/linux/debian/gpg | sudo apt-key add -`
So changing transport of HTTP to HTTPS of APT for OMV will do similar. It's safe.