### PR TITLE
Typo: "as a last resort", not "as a last resource"

### DIFF
--- a/installation/index.rst
+++ b/installation/index.rst
@@ -19,7 +19,7 @@ Installation variants:
 	* :doc:`Dedicated drive </installation/via_iso>` - Advised method via ISO image. This runs OMV from its own drive.
 	* :doc:`USB flash drive </installation/on_usb>` - This runs |omv| from a USB flash drive.
 	* :doc:`Debian Operating System </installation/on_debian>` - This runs |omv| as a services on top of a Debian OS.
-	* `Debian Operating System via deboostrap <https://forum.openmediavault.org/index.php/Thread/12070-GUIDE-DEBOOTSTRAP-Installing-Debian-into-a-folder-in-a-running-system/>`_. Use this as a last resource in case the installer does not recognize a specific essential hardware component like hard disk (NVME) or a network card that needs a higher kernel (backport).
+	* `Debian Operating System via deboostrap <https://forum.openmediavault.org/index.php/Thread/12070-GUIDE-DEBOOTSTRAP-Installing-Debian-into-a-folder-in-a-running-system/>`_. Use this as a last resort in case the installer does not recognize a specific essential hardware component like hard disk (NVME) or a network card that needs a higher kernel (backport).
 	* :doc:`SD card </installation/via_image>` - This runs |omv| from a SD card.
 
 First time use:


### PR DESCRIPTION
https://dictionary.cambridge.org/dictionary/english/as-a-last-resort