### PR TITLE
Use gender-neutral language to describe users.

### DIFF
--- a/administration/access_rights_management.rst
+++ b/administration/access_rights_management.rst
@@ -29,7 +29,7 @@ Group
 	Add or remove users from specific groups. In linux groups can be used to control
 	access to certain features and also for permissions.
 
-	Adding a user to the ``sudo`` group will give him root privileges, adding
+	Adding a user to the ``sudo`` group will give them root privileges, adding
 	a user to ``saned`` will give access to scanners, etc. By default all users created using
 	the |webui| are added to the ``users`` group (``gid=100``).
 
@@ -40,7 +40,7 @@ Public Key
 
 	- The user profile information (except password) is also stored in the internal |omv| database, along with the public keys.
 	- The grid shows information from internal database and also parses information from :file:`/etc/passwd` lines with a `UID` number higher than 1000. A user created in terminal is not in the internal database. This causes trouble with samba, as there is no user/password entry in the tdbsam file. Just click edit for the user, enter the same or new password, now the user has the linux and samba password synced.
-	- A user can log into the web interface to see his own profile information. Depending if the adminstrator has setup the username account to allow changes, they can change their password and mail account.
+	- A user can log into the web interface to see their own profile information. Depending if the adminstrator has setup the username account to allow changes, they can change their password and mail account.
 
 Import
 ^^^^^^
@@ -61,7 +61,7 @@ Example outputs::
 
 .. note::
 	- :file:`/etc/shells` will give you a list of valid shells.
-	- The last field is	a boolean for allowing the user to change his account.
+	- The last field is	a boolean for allowing the user to change their account.
 
 Paste the contents into the import dialog.
 

--- a/administration/general/certificates.rst
+++ b/administration/general/certificates.rst
@@ -48,7 +48,7 @@ number:
 
 :file:`/etc/ssl/certificates/openmediavault-<uuid>.cert`
 
-Private key file with the same :code:`<uuid>` suffix from to his certificate
+Private key file with the same :code:`<uuid>` suffix as their certificate
 pair.
 
 :file:`/etc/ssl/private/openmediavault-<uuid>.key`

--- a/administration/general/cron.rst
+++ b/administration/general/cron.rst
@@ -15,7 +15,7 @@ Options
 
 **Username:** Under what user should the command/script be executed. You can select root, system accounts and |omv| users.
 
-**Mail Notification:** Send all the command/script output to the mail defined in the username profile. If the task is running as root, the mail recipient will be the one defined in notifications for primary and secondary delivery. If |omv| user is defined in the task and has an email configured in his :doc:`profile </administration/access_rights_management>` the notification will be sent to that mail address.
+**Mail Notification:** Send all the command/script output to the mail defined in the username profile. If the task is running as root, the mail recipient will be the one defined in notifications for primary and secondary delivery. If |omv| user is defined in the task and has an email configured in their :doc:`profile </administration/access_rights_management>` the notification will be sent to that mail address.
 
 Configuration
 -------------

--- a/administration/general/notifications.rst
+++ b/administration/general/notifications.rst
@@ -18,7 +18,7 @@ The central MTA configuration is stored in :file:`/etc/postfix/main.cf`
 
 When a scheduled task is defined to run as a certain user the output generated from that task, will be sent to that user defined mail.
 
-The last line is the catch all address. For example a scheduled task set to be run as user with no mail defined in his profile will get the output generated sent to the catch all address (``rootthe@gmail.com``). The same will happen with any other mail action intended for an undefined user (not in that list)
+The last line is the catch all address. For example a scheduled task set to be run as user with no mail defined in their profile will get the output generated sent to the catch all address (``rootthe@gmail.com``). The same will happen with any other mail action intended for an undefined user (not in that list)
 
 Mails can be sent from terminal also with mail command. :command:`mail` receives from stdin.
 

--- a/administration/services/samba.rst
+++ b/administration/services/samba.rst
@@ -82,7 +82,7 @@ The login access in Samba is configured using privileges. This means they will n
 Privileges only gets login access and from there determines if user can read or write. If write access is enabled but files/folders have restricted permissions then write access is not possible using Samba.
 
 .. important::
-	Samba does not use PAM for login, it has a different password database. When the admin changes a username password (or the username changes his) using the |webui| what |omv| does is that it changes both the linux login password and the Samba internal database. If a username changes his password using shell, this will not be reflected in Samba log in.
+	Samba does not use PAM for login, it has a different password database. When the admin changes a username password (or the user changes their own) using the |webui| what |omv| does is that it changes both the linux login password and the Samba internal database. If a username changes their password using shell, this will not be reflected in Samba log in.
 
 Share types
 -----------
@@ -122,7 +122,7 @@ Notice here if users are not set up privileges (that means blank tick boxes) any
 With these options valid, read only and write user directives will be ignored when mkconf regenerates the ``/etc/samba/smb.conf`` file.
 
 .. note::
-	- The guest account is mapped to system account nobody, he doesn’t belong to group users, thus he HAS BY DEFAULT NO WRITE ACCESS just READ. This can be reverted modifying the POSIX permissions of the share to 777.
+	- The guest account is mapped to system account nobody, it doesn’t belong to group users, thus it has, by default, NO WRITE ACCESS just READ. This can be reverted modifying the POSIX permissions of the share to 777.
 	- These directives are NOT ACL.
 
 

--- a/howitworks.rst
+++ b/howitworks.rst
@@ -1,7 +1,7 @@
 How does it works?
 ##################
 
-|omv| is a complex piece of software. Developers can easily understand how it works by looking at the source code and developing plugins. For the average user is a little bit more complicated. Some of the mechanics on how it works are explained 	ahead.
+|omv| is a complex piece of software. Developers can easily understand how it works by looking at the source code and developing plugins. For the average user it is a little bit more complicated. Some of the mechanics on how it works are explained ahead.
 
 Essential elements:
 	**Frontend** The |webui|, is written in javascript using the extjs sencha framework. Is rendered using the nginx http engine.
@@ -153,8 +153,8 @@ After that is time for daemon reload, so:
 That php function performs also checks for dependancies, in case a configuration needs to be reconfigured or reloaded before/after another one.
 
 Why is zeroconf marked dirty?
-	Because the samba |omv| `code <https://github.com/openmediavault/openmediavault/blob/a846afb5a648cb89b2dad0fdf25ee7b261d89a78/deb/openmediavault/usr/share/openmediavault/engined/module/samba.inc#L266-L269>`_ indicates that whenever a change is performed in his section, zeroconf must be marked dirty. This is by design, avahi is configured to announce samba server if is enabled, so needs to know if |omv| Samba server is enabled or disabled. If the database shows it is disabled the avahi servie file will be removed
-	The module backend is something all plugins can use. For example a plugin that wants to use the privilege database model will have to listen to any changes in the |sf| database so it can reconfigure his files acordingly.
+	Because the samba |omv| `code <https://github.com/openmediavault/openmediavault/blob/a846afb5a648cb89b2dad0fdf25ee7b261d89a78/deb/openmediavault/usr/share/openmediavault/engined/module/samba.inc#L266-L269>`_ indicates that whenever a change is performed in this section, zeroconf must be marked dirty. This is by design, avahi is configured to announce samba server if is enabled, so needs to know if |omv| Samba server is enabled or disabled. If the database shows it is disabled the avahi servie file will be removed
+	The module backend is something all plugins can use. For example, a plugin that wants to use the privilege database model will have to listen to any changes in the |sf| database so it can reconfigure its files acordingly.
 
 What can break the web interface?
 	As explained, the |webui| depends on several third party software components.


### PR DESCRIPTION
Avoid his/he/him pronouns. Other trivial grammar improvements.