### PR TITLE
changing a "no" to tentative "yes"

### DIFF
--- a/faq.rst
+++ b/faq.rst
@@ -49,7 +49,8 @@ I´ve lost the |webui| password. How do I reset it?
 	|webui| password.
 
 Can I backup or restore an existing |omv| configuration?
-	No. Keep the file :file:`/etc/openmediavault/config.xml` for references
+	There is no regular backup/restore procedure, but yes, in some way:
+	keep the file :file:`/etc/openmediavault/config.xml` for references
 	purposes if the option is to go for a clean re-install.
 
 What is the default HTTP engine of |omv|?


### PR DESCRIPTION
"Can I backup or restore an existing |omv| configuration?"
The answer began with a "No", but the text then explains a way (to backup config.xml).

Im my view, the answer should start with a tentative "There is no regular backup/restore procedure, but yes, in some way:". My pull request proposes such a change.