### PR TITLE
Update notifications.rst

### DIFF
--- a/administration/general/notifications.rst
+++ b/administration/general/notifications.rst
@@ -67,9 +67,9 @@ Gmail can be used in notifications. If you have 2FA enabled for the account, the
 
 	SMTP Server: smtp.gmail.com
 	SMTP Port: 587
-	SSL/TLS: Yes
+	Encryption mode: STARTTLS
 	Sender email: rootthe@gmail.com (include domain)
-	Authentication: Yes
+	Authentication required: Yes
 	Username: rootthe@gmail.com (include domain)
 	Password: <the app password here>
 	Primary email: rootthe@gmail.com


### PR DESCRIPTION
According my own experience and the forum topic bellow, STARTTLS is required for gmail.

https://forum.openmediavault.org/index.php?thread/31838-postfix-ssl-tls-wrong-version-for-gmail-notifications/&postID=234849&highlight=postfix%2Bnetwork%2Bunreachable#post249430