### PR TITLE
Corrected the port number where the documentation is hosted locally.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Build the HTML code
 
 	$ make autobuild
 
-Now open <http://localhost:8000/> in your browser to view the documentation.
+Now open <http://localhost:8080/> in your browser to view the documentation.
 Any changes to the documentation code will be rendered now immediatelly.
 
 Cleanup the HTML code


### PR DESCRIPTION
It started serving on port 8080 instead of 8000 for me. I'm on Ubuntu 21.10. Is it the same for everyone else?

![image](https://user-images.githubusercontent.com/18510187/147186034-ecaa9126-f8b7-4ed5-a95e-de73a3fb7517.png)
