### PR TITLE
Update support.rst

### DIFF
--- a/support.rst
+++ b/support.rst
@@ -18,7 +18,7 @@ community. The current support channels are:
 
 **IRC**
 
-We have a support IRC channel at freenode servers, just type ``/join #openmediavault``
+We have a support IRC channel at Libera servers, just type ``/join #openmediavault``
 in your favourite IRC client, type your question and wait for someone available
 to help you.
 


### PR DESCRIPTION
Could we update the info for the changed irc servers 
Freenode (old) -> Libera (new).
Could someone committed to the project please contact support@libera.chat to claim the channel on Libera?
It is currently afloat with no Ops. Previsously subzero79 would be around to ask/help but I haven't seem him in a long time and he even seems to be MIA on the forum atm 
subzero79 moderator: Male 42 from Queensland, Australia Member since Jun 8th 2014 Last Activity: Sep 1st 2021
