### PR TITLE
Minor clean-up

### DIFF
--- a/installation/on_debian.rst
+++ b/installation/on_debian.rst
@@ -33,7 +33,7 @@ instructions only partially work. Please refer to a specific `installation scrip
 Install the |omv| keyring manually::
 
     apt-get install --yes gnupg
-    wget --quiet --output-document=- https://packages.openmediavault.org/public/archive.key | gpg --dearmor --output "/usr/share/keyrings/openmediavault-archive-keyring.gpg"
+    wget --quiet --output-document=- https://packages.openmediavault.org/public/archive.key | gpg --dearmor --output --yes "/usr/share/keyrings/openmediavault-archive-keyring.gpg"
 
 Add the package repositories::
 

--- a/installation/on_debian.rst
+++ b/installation/on_debian.rst
@@ -33,7 +33,7 @@ instructions only partially work. Please refer to a specific `installation scrip
 Install the |omv| keyring manually::
 
     apt-get install --yes gnupg
-    wget --quiet --output-document=- https://packages.openmediavault.org/public/archive.key | gpg --dearmor | tee "/usr/share/keyrings/openmediavault-archive-keyring.gpg" >/dev/null
+    wget --quiet --output-document=- https://packages.openmediavault.org/public/archive.key | gpg --dearmor --output "/usr/share/keyrings/openmediavault-archive-keyring.gpg"
 
 Add the package repositories::
 

--- a/installation/on_debian.rst
+++ b/installation/on_debian.rst
@@ -33,7 +33,7 @@ instructions only partially work. Please refer to a specific `installation scrip
 Install the |omv| keyring manually::
 
     apt-get install --yes gnupg
-    wget --quiet --output-document=- https://packages.openmediavault.org/public/archive.key | gpg --dearmor | tee "/usr/share/keyrings/openmediavault-archive-keyring.gpg"
+    wget --quiet --output-document=- https://packages.openmediavault.org/public/archive.key | gpg --dearmor | tee "/usr/share/keyrings/openmediavault-archive-keyring.gpg" >/dev/null
 
 Add the package repositories::
 
@@ -63,7 +63,7 @@ Install the |omv| package::
         --no-install-recommends \
         --option DPkg::Options::="--force-confdef" \
         --option DPkg::Options::="--force-confold" \
-        install openmediavault-keyring openmediavault
+        install openmediavault
 
 Populate the |omv| database with several existing system settings, e.g. the network configuration::
 


### PR DESCRIPTION
Prevents garbled output when importing the keyring:

![Screenshot from 2023-11-15 15-10-40](https://github.com/openmediavault/openmediavault-docs/assets/550915/09b9c70a-c7e1-42c1-8b01-3952a6e16db6)

Also, no need to install openmediavault-keyring package specifically since it's an openmediavault package dependency.