### PR TITLE
Update plugins.rst for SFTP

### DIFF
--- a/plugins.rst
+++ b/plugins.rst
@@ -24,7 +24,7 @@ The following is the list of official plugins by |omv|. Their availability depen
 * **ClamAV**: Provides Clam AntiVirus (ClamAV). It is a free software, cross-platform and open-source antivirus software toolkit able to detect many types of malicious software, including viruses
 * **Diskstats**: Complementary plugin to extend system statistics collection by adding I/O statistic graphs.
 * **Forked-daap**: Provides a daap protocol music server.
-* **FTP**: Provides a modular FTP/SFTP/FTPS server.
+* **FTP**: Provides a modular FTP/FTPS server.
 * **LVM2**: LVM managing. Create volume groups and logical partitions.
 * **NUT**: Controlling and configuring UPS. The driver support is based on NUT.
 * **Onedrive** (amd64, arm64, armhf, i386 only): Synchronizing a shared folder with Microsoft OneDrive cloud storage.
@@ -32,6 +32,7 @@ The following is the list of official plugins by |omv|. Their availability depen
 * **Shairport**: Provides Airtunes emulator. Stream music wirelessly to your iPod/iPad/iPhone/iTunes.
 * **ShareRootFs**: Provides shared directories on root file system.
 * **SNMP**: Provides Simple Network Management Protocol (SNMP). SNMP is an Internet Standard protocol for collecting and organizing information about managed devices on IP networks.
+* **SFTP**: Provides an SFTP server (on another port than SSH).
 * **TFtp**: Provides Trivial File Transfer Protocol (TFTP). TFTP is a simple lockstep File Transfer Protocol which allows a client to get a file from or put a file onto a remote host.
 * **USB Backup**: Backup internal data to external disks on scheduled basis or on plug drive event.
 

--- a/plugins.rst
+++ b/plugins.rst
@@ -32,7 +32,6 @@ The following is the list of official plugins by |omv|. Their availability depen
 * **Shairport**: Provides Airtunes emulator. Stream music wirelessly to your iPod/iPad/iPhone/iTunes.
 * **ShareRootFs**: Provides shared directories on root file system.
 * **SNMP**: Provides Simple Network Management Protocol (SNMP). SNMP is an Internet Standard protocol for collecting and organizing information about managed devices on IP networks.
-* **SFTP**: Provides an SFTP server (on another port than SSH).
 * **TFtp**: Provides Trivial File Transfer Protocol (TFTP). TFTP is a simple lockstep File Transfer Protocol which allows a client to get a file from or put a file onto a remote host.
 * **USB Backup**: Backup internal data to external disks on scheduled basis or on plug drive event.
 


### PR DESCRIPTION
Unlike what the current page says, the FTP server plugin does not provide SFTP (it provides FTP and FTPS), while there is another plugin for FTP. Having a single line misleads users interested in SFTP to install the FTP plugin and wonder how to get SFTP.