### PR TITLE
Clarify 4 GiB disk min

### DIFF
--- a/prerequisites.rst
+++ b/prerequisites.rst
@@ -7,7 +7,7 @@ Before installing |omv| make sure your hardware is supported.
 * **RAM**: 1 GiB capacity
 * **HDD**:
 
-  * **System Drive**: min. 4 GiB capacity (but more than the capacity of the RAM)
+  * **System Drive**: min. 4 GiB capacity (plus the capacity of the RAM)
   * **Data Drive**: capacity according to your needs
 
 .. note::


### PR DESCRIPTION
On  a fresh install of OMV 7.0.32 from the ISO... although **YES** it will install and run on a 3GB partition with a 1GB swap partition (which is what you get if do the minimum RAM stated of 1 GiB).  

But if the **first** thing you do is system updates from the web UI then after a reboot you won't even have the space the install the most tiniest of packages such as tftpd, so I'd hate to think what would happen over time with even the smallest amount of logs.

Using 'apt clean' might help a little, but there no is way to do that on the web interface.  Ultimately it should be a 4 GiB minimum for the system partition plus whatever it makes for a swap partition.