### PR TITLE
users and group docs improved with missing informatino fixed #138

### DIFF
--- a/administration/users.rst
+++ b/administration/users.rst
@@ -9,6 +9,10 @@ between the Debian operating system and the OMV software system** internal datab
 
 **Users** in |omv| is divided into three subsections: ``Settings``, ``Users`` and ``Groups``.
 
+With this section we can manage also permissions of shared resources.
+Unlike user permissions, group permissions allow you to define access
+for multiple users to the same resource.
+
 About home user
 ^^^^
 
@@ -53,47 +57,67 @@ Allows to select a |sf| as root for *home* place for new users created in the
 User
 ====
 
-This allows to *Create* or *Edit* users as well as their permissions, there is a 
-special option that allows batch loading called *Import*. Those are under the "+" 
-button of the configuration panel.
+This allows to *Create* or *Edit* users as well as their *Permissions*, there is a
+special option that allows batch loading called *Import*.
+
+The options of *Create* and *Import* are under the "+" button of the configuration panel.
+
+The option of *Edit* an user is next to the "+" button.
+
+The option of *Permissions* are next to the "Edit" button.
+
+Erasing or deleting an user is the "Trash" icon next to the "Permission" button.
 
 Information
-    The table information displays all |omv| current users in listing format. 
-    Using the *table icon* button of the configuration panel, you can customized 
+    The table information displays all |omv| current users in listing format.
+    Using the *table icon* button of the configuration panel, you can customized
     the columns  of this listing format by add or remove information columns.
+
+    Take note that **to edit or delete an user you must select one** from the list.
 
 Create
 ^^^^
 
-This brings to you the creation form, important fields are:
+This brings to you the creation form, this option is offered after hit the "+"
+button of the configuration menu panel of the *Users* subsection. important fields are:
 
 Name
-    This must be only numbers and letters.
+    This must be only numbers and letters. Its the "username" of the login credentials
+    and must be all lowercase to avoid confution.
 
 Password
     This fiel will provide the password of the user.
 
 Group
-	This field allows to add or remove users from specific groups. Groups are the means of access 
+    This field allows to add or remove users from specific groups. Groups are the means of access
     for multiple users to multiple shared resources.
 
     Some groups only affect the system (as of Linux), others are specific to the |omv| system.
-	By default all users created using	the |webui| are added to the ``users`` group (``gid=100``).
+    By default all users created using	the |webui| are added to the ``users`` group (``gid=100``).
+
+Shell
+    The shell is only used for remote access to interact with the server.
+    By default the form will offers :command:`/bin/sh` shell, but is recommended usage of
+    the :command:`/bin/nologin` shell to prevent local and remote console access.
 
 Public Key
-	Add or remove :doc:`public keys </administration/services/ssh>` for granting remote access for users.
+    Add or remove :doc:`public keys </administration/services/ssh>` for granting remote access for users.
 
 
 Import
 ^^^^^^
 
-Designed for bulk user creation. Create a spreadsheet with the corresponding data as
-described in the import dialog window, save it as CSV (make sure the field separator is semicolon :code:`;`), then just
-simply::
+Designed for bulk user creation, it brings a form filed like a spreadsheet to fill up with the
+corresponding data as described in the import dialog window.
 
-$ cat usersfile.csv
+Those fields are the same as the form of the *Create* user subsection.
 
-Example outputs::
+The field of "uid" do not appears on the creation form, must be numeric
+and must be over 1000.
+
+The field of "disallowusermod" is a boolean for allowing user to change their account.
+
+Example data::
 
 	# <name>;<uid>;<tags>;<email>;<password>;<shell>;<group,group,...>;<disallowusermod>
 	user1;1001;user1;user1@myserver.com;password1;/bin/bash;sudo;1
@@ -102,13 +126,21 @@ Example outputs::
 	user4;1004;user4;user4@test.com;password4;;;1
 
 .. note::
-	- :file:`/etc/shells` will give you a list of valid shells.
-	- The last field is	a boolean for allowing the user to change their account.
+    You can create a spreadsheet with the corresponding data as described in the import dialog window
+    save it as CSV using the field separator as semicolon to carry its content in plain text editor,
+    then copy its content and paste the contents into the import dialog.
 
-Paste the contents into the import dialog.
+Edit
+^^^^
+
+The button to edit and modify user details. You only can modify one user per time.
+
+Its basically the same form of the creation option, same rules apply.
 
 Permissions
 ^^^^^^^^^^^
+
+The button to edit and modify users access. You only can modify one user per time.
 
 The button opens a window that displays all current existing |sf| and their
 permissions for selected user from the table. How the permissions are stored is
@@ -118,26 +150,72 @@ described further down in the :doc:`shared folder </administration/storage/share
 Group
 =====
 
+This allows to *Create* or *Edit* groups as well as their *Permissions*, there is a
+special option that allows batch loading called *Import*.
+
+The options of *Create* and *Import* are under the "+" button of the configuration panel.
+
+The option of *Edit* an user is next to the "+" button.
+
+The option of *Permissions* are next to the "Edit" button.
+
+Erasing or deleting an user is the "Trash" icon next to the "Permission" button.
+
+Information
+    The table information displays all |omv| current groups in listing format.
+    Using the *table icon* button of the configuration panel, you can customized
+    the columns  of this listing format by add or remove information columns.
+
+    Take note that **to edit or delete a group you must select one** from the list
+    and **this group must be not in usage** by any shared resource or user.
+
 Add
 ^^^
 
-Create groups and select the members. You can select current |omv| users
-and system accounts. Information is stored in ``config.xml`` and
-:file:`/etc/group`.
+This brings to you the creation form, this option is offered after hit the "+"
+button of the configuration menu panel of the *Users* subsection. important fields are:
+
+Name
+    This must be only numbers and letters. The group information is stored in ``config.xml`` and
+    the :file:`/etc/group` file.
+
+Members
+    This field allows to add or remove users from this group. Groups are the means of access
+    for multiple users to multiple shared resources. You can select current |omv| existing users.
+
+    Some groups only affect the system (as of Linux), others are specific to the |omv| system.
+    By default all users created using	the |webui| are added to the ``users`` group (``gid=100``).
 
 Import
 ^^^^^^
 
-Bulk import works in similar as user account import. Just a csv text,
-delimited with a semicolon :code:`;`. The dialog displays the necessary
-fields.
+Designed for bulk group creation, it brings a form filed like a spreadsheet to fill up with the
+corresponding data as described in the import dialog window; it works in similar as user account import.
+
+Those fields are the same as the form of the *Create* group subsection.
+
+The field of "uid" do not appears on the creation form, must be numeric
+and must be over 1000.
 
 Edit
 ^^^^
-Just to add or remove members from groups. Default groups created in the
-|webui| have a ``GID`` greater than ``1000``. Same as usernames, groups created
-in terminal are not stored in the internal database. Just edit, insert a
-comment and their information should now be stored in ``config.xml``.
+
+The button to edit and modify membership. You only can modify one grup per time,
+and means or implicts that one or several users will be modified at time.
+
+Its basically the same form of the creation option, same rules apply.
+
+Permissions
+^^^^^^^^^^^
+
+The button to edit and modify group access. You only can modify one group per time.
+
+Group permissions allow you to define access for multiple users to the same shared resource.
+
+The button opens a window that displays all current existing |sf| and their
+permissions for selected group from the table. How the permissions are stored is
+described further down in the :doc:`shared folder </administration/storage/sharedfolders>` section.
+
 
 Technical details
 =================
@@ -157,3 +235,4 @@ shell, this will prevent local and remote console access.
 	- The table shows information from internal database and also parses information from :file:`/etc/passwd` lines with a `UID` number higher than 1000. A user created in terminal is not in the internal database. This causes trouble with samba, as there is no user/password entry in the tdbsam file. Just click edit for the user, enter the same or new password, now the user has the linux and samba password synced.
 	- A user can log into the |webui| to see their own profile information. Depending if the administrator has setup the username account to allow changes, they can change their password and mail account.
 	- A non-privileged user can become a |webui| administrator by adding them to the ``openmediavault-admin`` group.
+	- When user or group are created information should now be stored in ``config.xml``.

--- a/administration/users.rst
+++ b/administration/users.rst
@@ -8,6 +8,7 @@ However, |omv| also maintains control over these users, **so management is a tea
 between the Debian operating system and the OMV software system** internal database.
 
 **Users** in |omv| is divided into three subsections: ``Settings``, ``Users`` and ``Groups``.
+Groups means access for multiple users to multiple shared resources.
 
 With this section we can manage also permissions of shared resources.
 Unlike user permissions, group permissions allow you to define access
@@ -155,11 +156,11 @@ special option that allows batch loading called *Import*.
 
 The options of *Create* and *Import* are under the "+" button of the configuration panel.
 
-The option of *Edit* an user is next to the "+" button.
+The option of *Edit* a group is next to the "+" button.
 
 The option of *Permissions* are next to the "Edit" button.
 
-Erasing or deleting an user is the "Trash" icon next to the "Permission" button.
+Erasing or deleting a group is the "Trash" icon next to the "Permission" button.
 
 Information
     The table information displays all |omv| current groups in listing format.
@@ -167,24 +168,25 @@ Information
     the columns  of this listing format by add or remove information columns.
 
     Take note that **to edit or delete a group you must select one** from the list
-    and **this group must be not in usage** by any shared resource or user.
+    and **this group must be not in usage** by any shared resource or any user..
 
 Add
 ^^^
 
 This brings to you the creation form, this option is offered after hit the "+"
-button of the configuration menu panel of the *Users* subsection. important fields are:
+button of the configuration menu panel of the *Groups* subsection. important fields are:
 
 Name
     This must be only numbers and letters. The group information is stored in ``config.xml`` and
     the :file:`/etc/group` file.
 
 Members
-    This field allows to add or remove users from this group. Groups are the means of access
-    for multiple users to multiple shared resources. You can select current |omv| existing users.
+    This field allows to add or remove users for this group.  You can select
+    current |omv| existing users.
 
-    Some groups only affect the system (as of Linux), others are specific to the |omv| system.
-    By default all users created using	the |webui| are added to the ``users`` group (``gid=100``).
+    Some groups only affect the system (as of Linux), others are specific to
+    the |omv| system. By default all users created using the |webui| are added
+    to the ``users`` group (``gid=100``).
 
 Import
 ^^^^^^
@@ -200,7 +202,7 @@ and must be over 1000.
 Edit
 ^^^^
 
-The button to edit and modify membership. You only can modify one grup per time,
+The button to edit and modify membership. You only can modify one group per time,
 and means or implicts that one or several users will be modified at time.
 
 Its basically the same form of the creation option, same rules apply.
@@ -210,7 +212,7 @@ Permissions
 
 The button to edit and modify group access. You only can modify one group per time.
 
-Group permissions allow you to define access for multiple users to the same shared resource.
+Group permissions allow you to define access (for multiple users) to shared resources.
 
 The button opens a window that displays all current existing |sf| and their
 permissions for selected group from the table. How the permissions are stored is
@@ -224,6 +226,9 @@ When a user is created |omv| backend executes :command:`useradd` in non-interact
 mode with all the information passed from the form fields, this command also creates an
 entry in :file:`/etc/passwd`, a hashed password in :file:`/etc/shadow`. Samba service is watching any changes
 in users database section so it also sets the password in the Samba tdbsam storage backend.
+
+Unless normal action of :command:`useradd`, |omv| backend when performs such action
+do not create a personal group; the non-interactive mode will not demand this.
 
 The mail field is used for cron jobs when the task is selected to run as
 specific user. By default users are created with :command:`/bin/nologin`

--- a/administration/users.rst
+++ b/administration/users.rst
@@ -1,272 +1,220 @@
 Users
 #####
 
-User management in |omv| is supported by the users mnagement of the operating system 
-it runs on.
+The user management in |omv| is provided by the user management of the
+operating system on which it is running.
 
-However, |omv| also maintains control over these users, **so management is a team effort
-between the Debian operating system and the OMV software system** internal database.
+However, |omv| also maintains control over these users, **so management is a team effort**
+between the Debian operating system and the internal database of |omv|.
 
-**Users** management is divided into three subsections: ``Settings``, ``Users`` and ``Groups``.
+Users that are managed via the |webui| are so-called *non-system users*.
+Their *UID* is in a specific range, usually from 1000 to 60000. The same applies
+to groups that are managed via the |webui|. Their *GID* is in a specific
+range, usually from 1000 to 60000. Check ``/etc/login.defs`` for more information.
 
-Groups means access for multiple users to multiple shared resources.
+The **Users** management section in the |webui| is divided into three
+subsections: ``Settings``, ``Users`` and ``Groups``.
 
-An user can log into the |webui| to see their own profile information.
+Users can log into the |webui| to see their own profile information. The
+administrator can prohibit this behaviour for each user individually.
 
-With this section we can manage also permissions of shared resources.
-Unlike user permissions, group permissions allow you to define access
-for multiple users to the same resource.
-
-About home user
-^^^^
-
-Due to the nature explained, users are supposed to have their own private place for
-files that is called "*home*", depending on the type of service, automatically becomes 
-a personal private shared location.
-
-This place is configured in the ``Settings`` subsection of the |webui| interface 
-of |omv|, as *User home directory*
 
 Settings
 ========
 
-This is the first subsection of the **Users** management section of |webui|.
+User home directory
+-------------------
 
-Allows to select a |sf| as root for *home* place for new users created in the
-|webui|.
+Due to the nature explained, users are supposed to have their own private place for
+files that is called "*home*", depending on the type of service, automatically becomes
+a personal private shared location.
 
-* If you dont enable *User home directory*, when created an user:
+You can select a |sf| as root for the *home* directories of all non-system users.
 
-  * Will not have a private place for files if you use the |omv| |webui|
-  * Will have a private place for files if you use :command:`useradd` command
-  * The "skel" templates from Debian only will be used in last case
+If *User home directory* is disabled and a new user is created, the following happens:
 
-* If you already enable *User home directory*, when created an user:
+  * No home directory will be created and assigned to the user
 
-  * Will have a private place for files no matter way you use to create!
-  * The "skel" templates from Debian will be used always
+If *User home directory* is enabled and a new user is created, the following happens:
 
-* If you disabled and re-enabled *User home directory* and viceversa:
+  * A home directory will be created in the selected |sf| and assigned to the user
+  * The "skel" templates from Debian will applied to the new home directory
 
-  * Previously existing users created before enabling/disabling this setting 
-    will not have their *home* directory moved to the new location.
-  * Previously existing users  created before enabling/disabling this setting
-    can change *home* by editing :file:`/etc/passwd` to point them to the new 
-    location.
-  * Also existing users data in default linux location :file:`/home`
-    or previously existing *home* has to be moved manually too.
+If *User home directory* is enabled, the following actions will be performed:
+
+  * The home directory path will be updated for all existing non-system users.
+  * The previous home directory content will NOT be moved to the new location. This has to be done manually.
+
+If *User home directory* is disabled, the following actions will be performed:
+
+  * The home directory will be unset for all existing non-system users.
+  * The home directory content will NOT be deleted.
+
 
 User
 ====
 
-This allows to *Create* or *Edit* users as well as their *Permissions*, there is a
-special option that allows batch loading called *Import*.
-
-The options of *Create* and *Import* are under the "+" button of the configuration panel.
-
-The option of *Edit* an user is next to the "+" button.
-
-The option of *Permissions* are next to the "Edit" button.
-
-Erasing or deleting an user is the "Trash" icon next to the "Permission" button.
-
-Information
-    The table information displays all |omv| current users in listing format.
-    Using the *table icon* button of the configuration panel, you can customized
-    the columns  of this listing format by add or remove information columns.
-
-    Take note that **to edit or delete an user you must select one** from the list.
+This page lists all non-system users and allows you to *Create* or *Edit*
+those users as well as their |sf| *Permissions*. There is also a special
+option that allows you to *Import* multiple users at once.
 
 Create
-^^^^
+------
 
-This brings to you the creation form, this option is offered after hit the "+"
-button of the configuration menu panel of the *Users* subsection. important fields are:
+The following form fields are available:
 
 Name
     This must be only numbers and letters. Its the "username" of the login credentials
-    and must be all lowercase to avoid confution.
+    and must be all lowercase to avoid confusion.
 
 Password
-    This fiel will provide the password of the user.
+    This field will provide the password of the user.
 
-Group
+Shell
+    The shell is only used for remote access to interact with the server.
+    By default the form will offers :command:`/usr/bin/sh` shell, but is recommended usage of
+    the :command:`/usr/bin/nologin` shell to prevent local and remote console access.
+
+Groups
     This field allows to add or remove users from specific groups. Groups are the means of access
     for multiple users to multiple shared resources.
 
     Some groups only affect the system (as of Linux), others are specific to the |omv| system.
     By default all users created using the |webui| are added to the ``users`` group (``gid=100``).
 
-Shell
-    The shell is only used for remote access to interact with the server.
-    By default the form will offers :command:`/bin/sh` shell, but is recommended usage of
-    the :command:`/bin/nologin` shell to prevent local and remote console access.
+SSH public keys
+    Add or remove :doc:`public SSH keys </administration/services/ssh>` for granting remote access for users.
 
-Public Key
-    Add or remove :doc:`public keys </administration/services/ssh>` for granting remote access for users.
+Disallow account modification
+    Disallow the user to modify their own account information.
 
+Tags
+    Specify tags to categorize the user.
 
-.. attention::
-
-    Depending if the administrator has setup the username account to allow changes,
-    they can change their password and mail account.
 
 Import
-^^^^^^
+------
 
-Designed for bulk user creation, it brings a form filed like a spreadsheet to fill up with the
-corresponding data as described in the import dialog window.
+Designed for bulk user creation. The user data must be entered as CSV data.
+An example is prepared as a comment.
 
-Those fields are the same as the form of the *Create* user subsection.
+Those fields are the same as the form of the *Create* user page.
 
-The field of "uid" do not appears on the creation form, must be numeric
-and must be over 1000.
-
-The field of "disallowusermod" is a boolean for allowing user to change their account.
+The field of *UID* must be numeric and must be in the range from 1000 to 60000 (check ``/etc/login.defs`` for more information).
 
 Example data::
 
-	# <name>;<uid>;<tags>;<email>;<password>;<shell>;<group,group,...>;<disallowusermod>
-	user1;1001;user1;user1@myserver.com;password1;/bin/bash;sudo;1
-	user2;1002;user2;user2@my.com;password2;/bin/sh;;0
-	user3;1003;user3;user3@example.com;password3;/bin/false;;1
-	user4;1004;user4;user4@test.com;password4;;;1
+    # <name>;<uid>;<tags>;<email>;<password>;<shell>;<group,group,...>;<disallowusermod>
+    user1;1001;user1;user1@myserver.com;password1;/bin/bash;sudo;1
+    user2;1002;user2;user2@my.com;password2;/bin/sh;;0
+    user3;1003;user3;user3@example.com;password3;/bin/false;;1
+    user4;1004;user4;user4@test.com;password4;;;1
+
+Edit
+----
+
+Here you can modify the user information, the fields are the same as the form of the *Create* user page.
+
+Permissions
+-----------
+
+All existing |sf| and the access rights of the user to be edited are displayed
+on this page. The following access rights are available:
+
+- Read/Write
+- Read-only
+- No access
+
+These settings are used by the services to configure the access rights for the users.
 
 .. note::
 
-    You can create a spreadsheet with the corresponding data as described in the import dialog window
-    save it as CSV using the field separator as semicolon to carry its content in plain text editor,
-    then copy its content and paste the contents into the import dialog.
+    Please note that these settings have no effect on file system permissions.
 
-Edit
-^^^^
-
-The button to edit and modify user details. You only can modify one user per time.
-
-Its basically the same form of the creation option, same rules apply.
-
-Permissions
-^^^^^^^^^^^
-
-The button to edit and modify users access. You only can modify one user per time.
-
-The button opens a window that displays all current existing |sf| and their
-permissions for selected user from the table. How the permissions are stored is
-described further down in the :doc:`shared folder </administration/storage/sharedfolders>` section.
+How the permissions are stored is described further down in the :doc:`shared folder </administration/storage/sharedfolders>` section.
 
 
 Group
 =====
 
-This allows to *Create* or *Edit* groups as well as their *Permissions*, there is a
-special option that allows batch loading called *Import*.
+This page lists all non-system groups and allows you to *Create* or *Edit* those groups as well as their |sf| *Permissions*. There is also a special option that allows you to *Import* multiple groups at once.
 
-The options of *Create* and *Import* are under the "+" button of the configuration panel.
-
-The option of *Edit* a group is next to the "+" button.
-
-The option of *Permissions* are next to the "Edit" button.
-
-Erasing or deleting a group is the "Trash" icon next to the "Permission" button.
-
-Information
-    The table information displays all |omv| current groups in listing format.
-    Using the *table icon* button of the configuration panel, you can customized
-    the columns  of this listing format by add or remove information columns.
-
-    Take note that **to edit or delete a group you must select one** from the list
-    and **this group must be not in usage** by any shared resource or any user..
 
 Add
-^^^
+---
 
-This brings to you the creation form, this option is offered after hit the "+"
-button of the configuration menu panel of the *Groups* subsection. important fields are:
+The following form fields are available:
 
 Name
-    This must be only numbers and letters. The group information is stored in ``config.xml`` and
-    the :file:`/etc/group` file.
+    This must be only numbers and letters.
 
 Members
-    This field allows to add or remove users for this group.  You can select
-    current |omv| existing users.
-
-    Some groups only affect the system (as of Linux), others are specific to
-    the |omv| system. By default all users created using the |webui| are added
-    to the ``users`` group (``gid=100``).
+    This field allows to add or remove users for this group.
 
 Import
-^^^^^^
+------
 
-Designed for bulk group creation, it brings a form filed like a spreadsheet to fill up with the
-corresponding data as described in the import dialog window; it works in similar as user account import.
+Designed for bulk group creation. The group data must be entered as CSV data.
+An example is prepared as a comment.
 
-Those fields are the same as the form of the *Create* group subsection.
+Those fields are the same as the form of the *Create* group page.
 
-The field of "uid" do not appears on the creation form, must be numeric
-and must be over 1000.
+The field of *GID* must be numeric and must be in the range from 1000 to 60000 (check ``/etc/login.defs`` for more information).
 
 Edit
-^^^^
+----
 
-The button to edit and modify membership. You only can modify one group per time,
-and means or implicts that one or several users will be modified at time.
-
-Its basically the same form of the creation option, same rules apply.
+Here you can modify the group information, the fields are the same as the form of the *Create* group page.
 
 Permissions
-^^^^^^^^^^^
+-----------
 
-The button to edit and modify group access. You only can modify one group per time.
+All existing |sf| and the access rights of the group to be edited are displayed
+on this page. The following access rights are available:
 
-Group permissions allow you to define access (for multiple users) to shared resources.
+- Read/Write
+- Read-only
+- No access
 
-The button opens a window that displays all current existing |sf| and their
-permissions for selected group from the table. How the permissions are stored is
-described further down in the :doc:`shared folder </administration/storage/sharedfolders>` section.
+These settings are used by the services to configure the access rights for the groups.
+
+.. note::
+
+    Please note that these settings have no effect on file system permissions.
+
+How the permissions are stored is described further down in the :doc:`shared folder </administration/storage/sharedfolders>` section.
 
 
 Technical details
 =================
 
 When a user is created |omv| backend executes :command:`useradd` in non-interactive
-mode with all the information passed from the form fields, this command also creates an
-entry in :file:`/etc/passwd`, a hashed password in :file:`/etc/shadow`.
+mode with all the information passed from the form fields. This command is responsible for creating an
+entry in :file:`/etc/passwd` and a hashed password in :file:`/etc/shadow`.
 
-Services will perform sync operations like Samba service, that is watching any changes
-in users database section so it also sets the password in the Samba ``tdbsam`` storage backend;
-others just dont sync such operations like Rsync service, cos has their own user management.
-
-The mail field is used for cron jobs when the task is selected to run as
-specific user.
+The |omv| backend monitors all database changes to users to allow other services to react to these changes.
+This ensures, for example, that the *Samba* user database is updated when a user password is changed.
 
 .. attention::
 
-	- The user profile information (except password) is also stored in the
-          internal |omv| database, along with the public keys. So then when
-          user or group are created information should now be stored in ``config.xml``.
-	- The table shows information from internal database and also parses information
-          from :file:`/etc/passwd` lines with a `UID` number higher than 1000.
-	- A non-privileged user can become a |webui| administrator by adding them
-          to the ``openmediavault-admin`` group.
+    - The user profile information (except password) is also stored in the
+      internal |omv| database, along with the public keys.
+    - A non-privileged user can become a |webui| administrator by adding them
+      to the ``openmediavault-admin`` group.
 
 Manual management
-^^^^^^^^^^^^^^^^^
+-----------------
 
-Unless normal action of :command:`useradd`, |omv| backend when performs such action
-do not create a personal group.
+If a user is created via the |webui|, no corresponding group with the name of the user is created.
 
-A user created in terminal by the :command:`useradd` command will not be in the internal
-database. This causes trouble with some services; by example *Samba*, as there is no
-user/password entry in the ``tdbsam`` database of samba.
+A user created in terminal by the :command:`useradd` command will not be in the |omv| internal
+database. This causes trouble with some services, by example *Samba*, as there is no
+user/password entry in the ``tdbsam`` database of *Samba*.
 
 To synchronize users or groups that have not been created in the |webui|, simply
-perform an edit action and change the password or membership.
+perform an *Edit* action and change the password or membership.
 
-Shared Home
-^^^^^^^^^^^
+Shared home directories
+-----------------------
 
-The private file location or "*home*" place will become a shared resource of any user
-created, if *User Home directory* is already configure and place is valid.
-
-This becomes a shared resource only in some services, mostly Samba and Ftp services.
+If *User Home directory* is enabled and configured properly, then the home directories can be shared by some services as well, e.g. *Samba* and *FTP*.

--- a/administration/users.rst
+++ b/administration/users.rst
@@ -41,32 +41,44 @@ Allows to select a |sf| as root for *home* place for new users created in the
   * The "skel" templates from Debian will be used always
 
 * If you disabled and re-enabled *User home directory* and viceversa:
-  * Previously existing users created before enabling this setting will 
-    not have their *home* directory moved to this new location.
-  * You can manually edit :file:`/etc/passwd` to point them to the new 
-    location. Also existing users data in default linux location :file:`/home`
-    has to be moved manually.
+
+  * Previously existing users created before enabling/disabling this setting 
+    will not have their *home* directory moved to the new location.
+  * Previously existing users  created before enabling/disabling this setting
+    can change *home* by editing :file:`/etc/passwd` to point them to the new 
+    location.
+  * Also existing users data in default linux location :file:`/home`
+    or previously existing *home* has to be moved manually too.
 
 User
 ====
 
-Here you can create or modify user information and configure the user home folders.
-
-Add
-^^^^
+This allows to *Create* or *Edit* users as well as their permissions, there is a 
+special option that allows batch loading called *Import*. Those are under the "+" 
+button of the configuration panel.
 
 Information
-	The configuration panel gives you options to add, edit or remove users. The table displays all
-	|omv| current users.
+    The table information displays all |omv| current users in listing format. 
+    Using the *table icon* button of the configuration panel, you can customized 
+    the columns  of this listing format by add or remove information columns.
 
+Create
+^^^^
+
+This brings to you the creation form, important fields are:
+
+Name
+    This must be only numbers and letters.
+
+Password
+    This fiel will provide the password of the user.
 
 Group
-	Add or remove users from specific groups. In Linux groups can be used to control
-	access to certain features and also for permissions.
+	This field allows to add or remove users from specific groups. Groups are the means of access 
+    for multiple users to multiple shared resources.
 
-	Adding a user to the ``sudo`` group will give them root privileges, adding
-	a user to ``saned`` will give access to scanners, etc. By default all users created using
-	the |webui| are added to the ``users`` group (``gid=100``).
+    Some groups only affect the system (as of Linux), others are specific to the |omv| system.
+	By default all users created using	the |webui| are added to the ``users`` group (``gid=100``).
 
 Public Key
 	Add or remove :doc:`public keys </administration/services/ssh>` for granting remote access for users.

--- a/administration/users.rst
+++ b/administration/users.rst
@@ -7,8 +7,11 @@ it runs on.
 However, |omv| also maintains control over these users, **so management is a team effort
 between the Debian operating system and the OMV software system** internal database.
 
-**Users** in |omv| is divided into three subsections: ``Settings``, ``Users`` and ``Groups``.
+**Users** management is divided into three subsections: ``Settings``, ``Users`` and ``Groups``.
+
 Groups means access for multiple users to multiple shared resources.
+
+An user can log into the |webui| to see their own profile information.
 
 With this section we can manage also permissions of shared resources.
 Unlike user permissions, group permissions allow you to define access
@@ -17,11 +20,9 @@ for multiple users to the same resource.
 About home user
 ^^^^
 
-Due to the nature explained, users are supposed to have their own private place for files 
-that is called "*home*".
-
-This private file location or "*home*" place, **depending on the type of service, 
-automatically becomes a shared location**.
+Due to the nature explained, users are supposed to have their own private place for
+files that is called "*home*", depending on the type of service, automatically becomes 
+a personal private shared location.
 
 This place is configured in the ``Settings`` subsection of the |webui| interface 
 of |omv|, as *User home directory*
@@ -94,7 +95,7 @@ Group
     for multiple users to multiple shared resources.
 
     Some groups only affect the system (as of Linux), others are specific to the |omv| system.
-    By default all users created using	the |webui| are added to the ``users`` group (``gid=100``).
+    By default all users created using the |webui| are added to the ``users`` group (``gid=100``).
 
 Shell
     The shell is only used for remote access to interact with the server.
@@ -104,6 +105,11 @@ Shell
 Public Key
     Add or remove :doc:`public keys </administration/services/ssh>` for granting remote access for users.
 
+
+.. attention::
+
+    Depending if the administrator has setup the username account to allow changes,
+    they can change their password and mail account.
 
 Import
 ^^^^^^
@@ -127,6 +133,7 @@ Example data::
 	user4;1004;user4;user4@test.com;password4;;;1
 
 .. note::
+
     You can create a spreadsheet with the corresponding data as described in the import dialog window
     save it as CSV using the field separator as semicolon to carry its content in plain text editor,
     then copy its content and paste the contents into the import dialog.
@@ -224,20 +231,42 @@ Technical details
 
 When a user is created |omv| backend executes :command:`useradd` in non-interactive
 mode with all the information passed from the form fields, this command also creates an
-entry in :file:`/etc/passwd`, a hashed password in :file:`/etc/shadow`. Samba service is watching any changes
-in users database section so it also sets the password in the Samba tdbsam storage backend.
+entry in :file:`/etc/passwd`, a hashed password in :file:`/etc/shadow`.
 
-Unless normal action of :command:`useradd`, |omv| backend when performs such action
-do not create a personal group; the non-interactive mode will not demand this.
+Services will perform sync operations like Samba service, that is watching any changes
+in users database section so it also sets the password in the Samba ``tdbsam`` storage backend;
+others just dont sync such operations like Rsync service, cos has their own user management.
 
 The mail field is used for cron jobs when the task is selected to run as
-specific user. By default users are created with :command:`/bin/nologin`
-shell, this will prevent local and remote console access.
+specific user.
 
 .. attention::
 
-	- The user profile information (except password) is also stored in the internal |omv| database, along with the public keys.
-	- The table shows information from internal database and also parses information from :file:`/etc/passwd` lines with a `UID` number higher than 1000. A user created in terminal is not in the internal database. This causes trouble with samba, as there is no user/password entry in the tdbsam file. Just click edit for the user, enter the same or new password, now the user has the linux and samba password synced.
-	- A user can log into the |webui| to see their own profile information. Depending if the administrator has setup the username account to allow changes, they can change their password and mail account.
-	- A non-privileged user can become a |webui| administrator by adding them to the ``openmediavault-admin`` group.
-	- When user or group are created information should now be stored in ``config.xml``.
+	- The user profile information (except password) is also stored in the
+          internal |omv| database, along with the public keys. So then when
+          user or group are created information should now be stored in ``config.xml``.
+	- The table shows information from internal database and also parses information
+          from :file:`/etc/passwd` lines with a `UID` number higher than 1000.
+	- A non-privileged user can become a |webui| administrator by adding them
+          to the ``openmediavault-admin`` group.
+
+Manual management
+^^^^^^^^^^^^^^^^^
+
+Unless normal action of :command:`useradd`, |omv| backend when performs such action
+do not create a personal group.
+
+A user created in terminal by the :command:`useradd` command will not be in the internal
+database. This causes trouble with some services; by example *Samba*, as there is no
+user/password entry in the ``tdbsam`` database of samba.
+
+To synchronize users or groups that have not been created in the |webui|, simply
+perform an edit action and change the password or membership.
+
+Shared Home
+^^^^^^^^^^^
+
+The private file location or "*home*" place will become a shared resource of any user
+created, if *User Home directory* is already configure and place is valid.
+
+This becomes a shared resource only in some services, mostly Samba and Ftp services.

--- a/administration/users.rst
+++ b/administration/users.rst
@@ -1,7 +1,51 @@
 Users
 #####
 
-In this section you can create, edit and access information of |omv| users and groups.
+User management in |omv| is supported by the users mnagement of the operating system 
+it runs on.
+
+However, |omv| also maintains control over these users, **so management is a team effort
+between the Debian operating system and the OMV software system** internal database.
+
+**Users** in |omv| is divided into three subsections: ``Settings``, ``Users`` and ``Groups``.
+
+About home user
+^^^^
+
+Due to the nature explained, users are supposed to have their own private place for files 
+that is called "*home*".
+
+This private file location or "*home*" place, **depending on the type of service, 
+automatically becomes a shared location**.
+
+This place is configured in the ``Settings`` subsection of the |webui| interface 
+of |omv|, as *User home directory*
+
+Settings
+========
+
+This is the first subsection of the **Users** management section of |webui|.
+
+Allows to select a |sf| as root for *home* place for new users created in the
+|webui|.
+
+* If you dont enable *User home directory*, when created an user:
+
+  * Will not have a private place for files if you use the |omv| |webui|
+  * Will have a private place for files if you use :command:`useradd` command
+  * The "skel" templates from Debian only will be used in last case
+
+* If you already enable *User home directory*, when created an user:
+
+  * Will have a private place for files no matter way you use to create!
+  * The "skel" templates from Debian will be used always
+
+* If you disabled and re-enabled *User home directory* and viceversa:
+  * Previously existing users created before enabling this setting will 
+    not have their *home* directory moved to this new location.
+  * You can manually edit :file:`/etc/passwd` to point them to the new 
+    location. Also existing users data in default linux location :file:`/home`
+    has to be moved manually.
 
 User
 ====
@@ -15,14 +59,6 @@ Information
 	The configuration panel gives you options to add, edit or remove users. The table displays all
 	|omv| current users.
 
-	When a user is created |omv| backend executes :command:`useradd` in non-interactive
-	mode with all the information passed from the form fields, this command also creates an
-	entry in :file:`/etc/passwd`, a hashed password in :file:`/etc/shadow`. Samba service is watching any changes
-	in users database section so it also sets the password in the Samba tdbsam storage backend.
-
-	The mail field is used for cron jobs when the task is selected to run as
-	specific user. By default users are created with :command:`/bin/nologin`
-	shell, this will prevent local and remote console access.
 
 Group
 	Add or remove users from specific groups. In Linux groups can be used to control
@@ -35,12 +71,6 @@ Group
 Public Key
 	Add or remove :doc:`public keys </administration/services/ssh>` for granting remote access for users.
 
-.. note::
-
-	- The user profile information (except password) is also stored in the internal |omv| database, along with the public keys.
-	- The table shows information from internal database and also parses information from :file:`/etc/passwd` lines with a `UID` number higher than 1000. A user created in terminal is not in the internal database. This causes trouble with samba, as there is no user/password entry in the tdbsam file. Just click edit for the user, enter the same or new password, now the user has the linux and samba password synced.
-	- A user can log into the |webui| to see their own profile information. Depending if the administrator has setup the username account to allow changes, they can change their password and mail account.
-	- A non-privileged user can become a |webui| administrator by adding them to the ``openmediavault-admin`` group.
 
 Import
 ^^^^^^
@@ -72,14 +102,6 @@ The button opens a window that displays all current existing |sf| and their
 permissions for selected user from the table. How the permissions are stored is
 described further down in the :doc:`shared folder </administration/storage/sharedfolders>` section.
 
-Settings
-^^^^^^^^
-
-Option to select a |sf| as root for home folders for new users created in the
-|webui|. Previously existing users created before enabling this setting will not have
-their home folders moved to this new location. You can manually edit :file:`/etc/passwd`
-to point them to the new location. Also existing users data in default linux location :file:`/home`
-has to be moved manually.
 
 Group
 =====
@@ -104,3 +126,22 @@ Just to add or remove members from groups. Default groups created in the
 |webui| have a ``GID`` greater than ``1000``. Same as usernames, groups created
 in terminal are not stored in the internal database. Just edit, insert a
 comment and their information should now be stored in ``config.xml``.
+
+Technical details
+=================
+
+When a user is created |omv| backend executes :command:`useradd` in non-interactive
+mode with all the information passed from the form fields, this command also creates an
+entry in :file:`/etc/passwd`, a hashed password in :file:`/etc/shadow`. Samba service is watching any changes
+in users database section so it also sets the password in the Samba tdbsam storage backend.
+
+The mail field is used for cron jobs when the task is selected to run as
+specific user. By default users are created with :command:`/bin/nologin`
+shell, this will prevent local and remote console access.
+
+.. attention::
+
+	- The user profile information (except password) is also stored in the internal |omv| database, along with the public keys.
+	- The table shows information from internal database and also parses information from :file:`/etc/passwd` lines with a `UID` number higher than 1000. A user created in terminal is not in the internal database. This causes trouble with samba, as there is no user/password entry in the tdbsam file. Just click edit for the user, enter the same or new password, now the user has the linux and samba password synced.
+	- A user can log into the |webui| to see their own profile information. Depending if the administrator has setup the username account to allow changes, they can change their password and mail account.
+	- A non-privileged user can become a |webui| administrator by adding them to the ``openmediavault-admin`` group.


### PR DESCRIPTION
users and group docs improved with missing informatino fixed #138

* Completed documentation about user management
* described how works user management respect the OS
* described ithe complete management of the users
* removed unnecesary technical information
* completed missing information as #138 
* Better description about fileds to fill at the users/group forms for create/edit actions
* Closed #138 

**NOTE** this pull request can be edited by repository owners, and to avoid too much commit history they can squash it