### PR TITLE
Update filesystems.rst to recommend PVE kernel for ZFS

### DIFF
--- a/administration/storage/filesystems.rst
+++ b/administration/storage/filesystems.rst
@@ -70,4 +70,4 @@ Supported Filesystems
 
 .. note::
 	ZFS
-		Support for zfs is available through `ZoL <http://zfsonlinux.org/>`_ and requires the use of a third party plugin provided by omv-extras. This includes code added to the OMV filesystem backend. The plugin allows you to create shared folders for ZFS volumes. On AMD64, if ZFS support is desired, it is recommended to first use omv-extras install the third-party openmediavault-kernel plugin and use that to install the ProxMox (PVE) kernel, which has precompiled support for ZFS and may improve stability. After that, install the ZFS plugin.
+		Support for ZFS is available through `ZoL <http://zfsonlinux.org/>`_ and requires the use of a third party plugin provided by omv-extras. This includes code added to the OMV filesystem backend. The plugin allows you to create shared folders for ZFS volumes. On AMD64, if ZFS support is desired, it is recommended to first use omv-extras install the third-party openmediavault-kernel plugin and use that to install the ProxMox (PVE) kernel, which has precompiled support for ZFS and may improve stability. After that, install the ZFS plugin.

--- a/administration/storage/filesystems.rst
+++ b/administration/storage/filesystems.rst
@@ -70,4 +70,4 @@ Supported Filesystems
 
 .. note::
 	ZFS
-		Support for zfs is available through `ZoL <http://zfsonlinux.org/>`_ an uses a third party plugin provided by omv-extras. The development of the plugin was done in conjunction with core of |omv|, so new code was added in the filesystem backend to improve support for zfs. The plugin registers datasets and pools in the internal database so you can create shared folders for zfs volumes. The creation of zvols is automatically recognized by |omv| so you can format them and mount them in the |webui|. The iscsiplugin can also use these zvols block devices to export LUN's.
+		Support for zfs is available through `ZoL <http://zfsonlinux.org/>`_ and requires the use of a third party plugin provided by omv-extras. This includes code added to the OMV filesystem backend. The plugin allows you to create shared folders for ZFS volumes. On AMD64, if ZFS support is desired, it is recommended to first use omv-extras install the third-party openmediavault-kernel plugin and use that to install the ProxMox (PVE) kernel, which has precompiled support for ZFS and may improve stability. After that, install the ZFS plugin.


### PR DESCRIPTION
PVE kernel is recommended if using ZFS and should be installed before ZFS plugin in order to avoid problems. Update docs to reflect this. See thread https://forum.openmediavault.org/index.php?thread/55706-problem-with-new-omv7-kernel-update/&postID=414454#post414454