### PR TITLE
DNS and mailer notes in installation/on_debian.rst

### DIFF
--- a/installation/on_debian.rst
+++ b/installation/on_debian.rst
@@ -56,8 +56,8 @@ reconfiguring the network using the :command:`omv-firstaid` command.
 
 .. note::
 
-    if your IP address is configured by DHCP, the dhcp client may interfere
-    with systemd-resolved, preventing the download of additional packages
+    If your IP address is configured by DHCP, the dhcp client may interfere
+    with `systemd-resolved`, preventing the download of additional packages
     (``apt-get`` and ``wget`` fails).
     In that case, stop it with ``killall dhcpcd`` and repeat the
     ``resolvectl dns <INTERFACE> <DNS_SERVER_IP>`` command.


### PR DESCRIPTION
Following the installation instructions to the letter may result in a non-working DNS or mail system, adding notes on how to fix these.