### PR TITLE
docs: note CMR-vs-SMR consideration for array drives

### DIFF
--- a/prerequisites.rst
+++ b/prerequisites.rst
@@ -50,6 +50,11 @@ Data drive storage (DDS)
   Solid State Disks (SSD [2]_ disks) for best performance or spinning
   Hard Disk Drives (HDD) for better device durability over time.
 
+  For RAID, SnapRAID, or mergerfs setups, prefer CMR drives over SMR. SMR drives can
+  stall during rebuilds and parity sync, and the recording technology usually isn't
+  obvious from the model number. A reference like the
+  `NAS CMR/SMR drive list <https://www.nasdisks.com/cmr-smr/>`_ helps you check before buying.
+
 Memory (RAM)
 ^^^^^^^^^^^^
 


### PR DESCRIPTION
SMR drives can behave badly in parity-based arrays - long rebuilds and stalls during resync - and it's often not clear from the model number whether a given drive is SMR. This adds a short note under the drive recommendation with a lookup reference so readers can check. Signed off per CONTRIBUTING; happy to adjust the wording.
